### PR TITLE
Ignores changes to default action on https listeners

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -748,6 +748,13 @@ resource "aws_lb_listener" "frontend_https" {
     }
   }
 
+  # Added to ignore changes outside of terraform
+  lifecycle {
+    ignore_changes  = [
+      default_action
+    ]
+  }
+
   tags = merge(
     var.tags,
     var.https_listeners_tags,


### PR DESCRIPTION
This ignores changes to the listener default_action. Once we implement this module it should prevent us from needing to keep the target group index in sync.